### PR TITLE
Add extra_css_classes Gtk.Widget attribute

### DIFF
--- a/LuaGObject/override/Gtk4.lua
+++ b/LuaGObject/override/Gtk4.lua
@@ -27,6 +27,7 @@ Gtk.Widget._attribute = {
 	width = { get = Gtk.Widget.get_allocated_width },
 	height = { get = Gtk.Widget.get_allocated_height },
 	children = {},
+	extra_css_classes = {},
 }
 
 -- Allow to query a widget's currently-allocated dimensions by indexing .width or .height, and set the requested dimensions by assigning these pseudo-properties.
@@ -68,6 +69,21 @@ end
 
 function Gtk.Widget._attribute.children:get()
 	return setmetatable({ _widget = self }, widget_children_mt)
+end
+
+function Gtk.Widget._attribute.extra_css_classes:get()
+	error("%s: Cannot read extra_css_classes; attribute is read-only.", self._type.name)
+end
+function Gtk.Widget._attribute.extra_css_classes:set(value)
+	if type(value) == "string" then
+		value = { value }
+	end
+	if type(value) ~= "table" then
+		error("%s: Cannot assign value of type %s to extra_css_classes", self._type.name, type(value))
+	end
+	for _, c in pairs(value) do
+		self:add_css_class(c)
+	end
 end
 
 -- Simple container support --

--- a/tests/gtk.lua
+++ b/tests/gtk.lua
@@ -134,3 +134,14 @@ function gtk.notebook_container()
 	check(notebook:get_nth_page(1) == label2)
 	check(notebook:get_nth_page(2) == label3)
 end
+
+function gtk.extra_css_classes()
+	local Gtk = LuaGObject.Gtk
+	local box = Gtk.Box {
+		orientation = "VERTICAL",
+		extra_css_classes = { "linked" },
+	}
+	check(box:has_css_class "linked")
+	-- The .vertical CSS class comes from setting the orientation to vertical. By checking it here, the test ensures that the existing class isn't overwritten by extra_css_classes.
+	check(box:has_css_class "vertical")
+end


### PR DESCRIPTION
This new attribute functions like the css_classes built-in property of a Gtk.Widget, except it doesn't overwrite existing properties on an object. This allows classes like Gtk.Box—which adds a .vertical CSS class if it's oriented vertically—to function properly while setting CSS classes in the constructor.