### PR TITLE
0.10.5

### DIFF
--- a/LuaGObject/ffi.lua
+++ b/LuaGObject/ffi.lua
@@ -86,9 +86,15 @@ function ffi.load_enum(gtype, name)
 	end
 	local enum_class = core.record.cast(
 		type_class, is_flags and GObject.FlagsClass or GObject.EnumClass)
-	for i = 0, enum_class.n_values - 1 do
-		local val = core.record.fromarray(enum_class.values, i)
-		enum_component[core.upcase(val.value_nick):gsub('%-', '_')] = val.value
+	if GLib.check_version(2, 87, 0) then
+		for i = 0, enum_class.n_values - 1 do
+			local val = core.record.fromarray(enum_class.values, i)
+			enum_component[core.upcase(val.value_nick):gsub('%-', '_')] = val.value
+		end
+	else
+		for _, val in ipairs(enum_class.values) do
+			enum_component[core.upcase(val.value_nick):gsub('%-', '_')] = val.value
+		end
 	end
 	-- For GLib versions below 2.86, type_class was ref'd and needs to be unref'd
 	if GLib.check_version(2, 86, 0) then

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # Author: Pavel Holejsovsky <pavel.holejsovsky@gmail.com>
 # License: MIT
 
-VERSION = 0.10.4
+VERSION = 0.10.5
 MAKE ?= make
 
 ROCK = luagobject-$(VERSION)-1.rockspec

--- a/README.md
+++ b/README.md
@@ -92,6 +92,10 @@ LuaGObject is also built on the work of LGI's developers, listed below in no par
 
 ## History
 
+### 0.10.5 (2026-02-04)
+
+- Fixes an issue preventing LuaGObject from working with GLib version 2.87 and later
+
 ### 0.10.4 (2026-01-20)
 
 - Adds a new method :connect_signal to all GObject instances which uses GObject's internal mechanisms to connect to a signal, including those which LuaGObject fails to detect through introspection

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('LuaGObject', 'c',
-	version: '0.10.4',
+	version: '0.10.5',
 	meson_version: '>= 0.50.0',
 	default_options: [
 		'warning_level=2',


### PR DESCRIPTION
Fixes an issue with enum loading preventing LuaGObject from being used with certain libraries with GLib >= 2.87.0.