### PR TITLE
Gtk3/Gtk4: avoid redundant gtk_init when GTK is already initialized by the host

### DIFF
--- a/LuaGObject/override/Gtk3.lua
+++ b/LuaGObject/override/Gtk3.lua
@@ -21,10 +21,12 @@ local log = LuaGObject.log.domain('LuaGObject.Gtk3')
 
 assert(Gtk.get_major_version() <= 3)
 
--- Initialize GTK.
-Gtk.disable_setlocale()
-if not Gtk.init_check() then
-   return "gtk_init_check() failed"
+-- Initialize GTK, unless a host application already did so.
+if not Gdk.Display.get_default() then
+   Gtk.disable_setlocale()
+   if not Gtk.init_check() then
+      return "gtk_init_check() failed"
+   end
 end
 
 -- Gtk.Allocation is just an alias to Gdk.Rectangle.

--- a/LuaGObject/override/Gtk4.lua
+++ b/LuaGObject/override/Gtk4.lua
@@ -10,10 +10,12 @@ local log = LuaGObject.log.domain "LuaGObject.Gtk4"
 
 assert(Gtk.get_major_version() == 4)
 
--- Initialize GTK.
-Gtk.disable_setlocale()
-if not Gtk.init_check() then
-    return "gtk_init_check() failed"
+-- Initialize GTK, unless a host application already did so.
+if not Gdk.Display.get_default() then
+    Gtk.disable_setlocale()
+    if not Gtk.init_check() then
+        return "gtk_init_check() failed"
+    end
 end
 
 -- Gtk.Allocation overrides --


### PR DESCRIPTION
  LuaGObject's override/Gtk3.lua and override/Gtk4.lua both unconditionally
  call Gtk.disable_setlocale() followed by Gtk.init_check() as soon as the
  module loads. This assumes LuaGObject is the one responsible for
  initializing GTK.

  That assumption doesn't hold when LuaGObject is loaded as a plugin/scripting
  runtime inside a host application that has already called gtk_init() itself
  before any plugin gets a chance to run. In that case the disable_setlocale()
  call is a no-op that only produces a harmless but noisy GTK warning on every
  load:

      Gtk-WARNING **: gtk_disable_setlocale() must be called before gtk_init()

  This PR guards the initialization block on whether GTK has already been
  initialized, checked via Gdk.Display.get_default() returning non-nil. If a
  default display already exists, we assume the host already initialized GTK
  and skip the redundant disable_setlocale()/init_check() calls. Otherwise,
  behavior is unchanged from before.

  This is a small, backwards-compatible change: LuaGObject continues to
  initialize GTK itself when nothing else has, and now stays quiet when
  embedded in an application that already owns GTK's lifecycle